### PR TITLE
Move "Split action" from Cash redemption to Cash transfer

### DIFF
--- a/src/daml/Daml/Trading/Cash/CashRedemption.daml
+++ b/src/daml/Daml/Trading/Cash/CashRedemption.daml
@@ -23,31 +23,24 @@ template WithdrawalRequest
       do
         let
           adminBurnAccount = AccountKey with custodian = custodian, owner = custodian, id = Id CreateAccount.cashLabel
-
-        (accountCid,_) <- fetchByKey @CreateAccount.Account (custodian, owner)
-
-        (burnCid,remainingOpt) <- exercise accountCid CreateAccount.Split
-          with
-            holdingCid = holdingCid
-            amount = amount
+          burnCid : ContractId Fungible.I = coerceContractId holdingCid
 
         transferRequest <- create CashTransfer.Request
           with
             receiverAccount = adminBurnAccount
             instrument = instrument
             amount = amount
-            currentOwner = owner
-
+            owner = owner
+            custodian = custodian
         let
           newburnCid : ContractId Holding.I = coerceContractId burnCid
 
-        adminHoldingCid <- exercise transferRequest CashTransfer.Accept
+        (adminHoldingCid,remaining) <- exercise transferRequest CashTransfer.Accept
           with
             holdingCid = newburnCid
         exercise (coerceContractId adminHoldingCid : ContractId Fungible.I) Fungible.ArchiveFungible
-
-        let remainingCid = coerceContractId  <$> remainingOpt
-        pure (remainingCid)
+       
+        pure (remaining)
 
     choice Decline : ()
       controller custodian

--- a/src/daml/Daml/Trading/Cash/CashTransfer.daml
+++ b/src/daml/Daml/Trading/Cash/CashTransfer.daml
@@ -6,39 +6,49 @@ import Daml.Finance.Interface.Holding.Transferable qualified as Transferable (I,
 import Daml.Finance.Interface.Holding.Util (getAmount, getInstrument)
 import Daml.Finance.Interface.Instrument.Base.Instrument qualified as Instrument (K)
 import Daml.Finance.Interface.Types.Common (AccountKey(..))
+import Daml.Trading.Account.Account qualified as CreateAccount
 
 
 template Request
   with
+    custodian : Party
+    owner : Party
     receiverAccount : AccountKey
     instrument : Instrument.K
     amount : Decimal
-    currentOwner : Party
+    
   where
     signatory receiverAccount.owner
-    observer currentOwner
+    observer owner
 
     ensure amount > 0.0
 
-    choice Accept : ContractId Holding.I
+    choice Accept : (ContractId Holding.I, Optional (ContractId Holding.I))
       with
         holdingCid : ContractId Holding.I
-      controller currentOwner
+      controller owner
       do
         holding <- fetch holdingCid
-        getAmount holding === amount
         getInstrument holding === instrument
-
-        let transferableCid : ContractId Transferable.I = coerceContractId holdingCid
-
+        assertMsg "Balance insufficient" (amount <= getAmount holding)
+        
+        (accountCid,_) <- fetchByKey @CreateAccount.Account (custodian, owner)
+        (transferCid,remainingOpt) <- exercise accountCid CreateAccount.Split
+          with
+            holdingCid = holdingCid
+            amount = amount
+        let
+          transferableCid : ContractId Transferable.I = coerceContractId transferCid
         newTransferableCid <- exercise transferableCid Transferable.Transfer
           with
             newOwnerAccount = receiverAccount
-
-        pure $ toInterfaceContractId @Holding.I newTransferableCid
+        let
+          lastTransferableCid : ContractId Holding.I = coerceContractId newTransferableCid
+          remainingCid = coerceContractId  <$> remainingOpt
+        pure (lastTransferableCid,remainingCid)
 
     choice Decline : ()
-      controller currentOwner
+      controller owner
       do pure ()
 
     choice Withdraw : ()

--- a/src/daml/Daml/Trading/Tests/CashRedemptionTest.daml
+++ b/src/daml/Daml/Trading/Tests/CashRedemptionTest.daml
@@ -124,10 +124,14 @@ setup = do
       with
         receiverAccount = bobAccountKey
         instrument = cashInstrument
-        amount = 350.0
-        currentOwner = alice
+        amount = 330.0
+        owner = alice
+        custodian = admin
 
-  newbobHoldingCid <- submitMulti [alice] [public] do exerciseCmd transferRequestCid CashTransfer.Accept with holdingCid = aliceCashHoldingCidremaining
+  (newbobHoldingCid,newaliceRemainingCid) <- submitMulti [alice] [public] do
+    exerciseCmd transferRequestCid CashTransfer.Accept
+      with
+        holdingCid = aliceCashHoldingCidremaining
 
   bobRequestWithdrawal <- submit bob do
     createCmd CashRedemption.WithdrawalRequest
@@ -135,7 +139,7 @@ setup = do
         custodian = admin
         owner = bob
         holdingCid = newbobHoldingCid
-        amount = 150.0
+        amount = 130.0
         instrument = cashInstrument
 
   bobCashHoldingCidremaining <- submit admin do 

--- a/src/daml/Daml/Trading/Tests/CashTest.daml
+++ b/src/daml/Daml/Trading/Tests/CashTest.daml
@@ -101,8 +101,9 @@ setup = do
       with
         receiverAccount = bobAccountKey
         instrument = cashInstrument
-        amount = 1000.0
-        currentOwner = alice
+        amount = 800.0
+        owner = alice
+        custodian = admin
 
   newHoldingCid <- submitMulti [alice] [public] do exerciseCmd transferRequestCid CashTransfer.Accept with holdingCid = aliceCashHoldingCid
 


### PR DESCRIPTION
Move "Split action" from Cash redemption to Cash transfer to correct cash transfer issue.
Update the test case for both CashTest and CashRedemptionTest.
Reason: Only need to Split cash before transfer instead of splitting before withdrawal as current.